### PR TITLE
Trim command before parsing

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -30,7 +30,7 @@ export interface Help {
 type Command = Remind | List | Delete | Help;
 
 export const parseCommand = async (cmd: string, orig: ZulipOrig, getTimezone: GetTimezone): Promise<Command> => {
-  const verb = cmd.split(' ')[0];
+  const verb = cmd.trim().split(' ')[0];
   if (verb == 'list') return { verb };
   if (verb == 'help' || verb == 'halp' || verb == 'h') return { verb: 'help' };
   if (verb == 'delete' || verb == 'del' || verb == 'remove') return parseDelete(cmd);


### PR DESCRIPTION
Since people seem to keep adding extra spaces at the start after the ping which causes the commands to fail.