### PR TITLE
Fix Jerusalem timezone getting wrong offsets

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -47,7 +47,7 @@ const parseRemind = async (cmd: string, orig: Msg, getTimezone: GetTimezone): Pr
     cmd,
     {
       instant: new Date(),
-      timezone: getUTCOffset(new Date(), findTimeZone(timezone)).abbreviation,
+      timezone: -getUTCOffset(new Date(), findTimeZone(timezone)).offset,
     },
     {
       forwardDate: true,


### PR DESCRIPTION
IST stands for both "Israel Standard Time" and "Indian Standard Time" which are completely different offsets.

Pass minute offset to chrono instead fo avoid the ambiguity.