### PR TITLE
Minify image, optimize build and docker-compose.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,22 @@
-FROM debian:buster-slim
+FROM alpine:latest
 
 LABEL author="Fabian Hintringer" \
-    name="reminder-bot" \
-    version=1.0.0
+      name="reminder-bot" \
+      version="1.0.0"
 
-ARG REDIS_PORT \
-     REDIS_HOST \
-     REDIS_PASSWORD
+# Install dependencies, Node.js, and Yarn
+RUN apk add --no-cache curl bash nodejs npm && npm install -g yarn
 
-ENV REDIS_HOST=$REDIS_HOST \
-    REDIS_PORT=$REDIS_PORT \
-    REDIS_PASSWORD=${REDIS_PASSWORD}
+# Set work directory and copy application code
+WORKDIR /app
+COPY . .
 
-RUN mkdir -p /var/reminder-bot
+# Install Node.js dependencies
+RUN yarn install
 
-COPY ./ /var/reminder-bot/
+# If you have an entrypoint script, ensure it's executable
+# Uncomment the next line if your entrypoint script is used
+# RUN chmod +x ./entrypoint.sh
 
-RUN cd /var/reminder-bot \
-    && apt-get update \
-    && apt-get upgrade -y \
-    && apt-get install curl unzip -y \
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash \
-    && export NVM_DIR="$HOME/.nvm" \
-    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
-    && [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion" \
-    && nvm install 14.4.0 -y\
-    && apt-get update \
-    && apt-get install npm -y\
-    && npm install -g npm@7.20.0 \
-    && npm install --global yarn --no-optionals -y \  
-    && yarn install \
-    && chmod +x /var/reminder-bot/entrypoint.sh 
-
-ENTRYPOINT /var/reminder-bot/entrypoint.sh ${REDIS_HOST} ${REDIS_PORT} ${REDIS_PASSWORD}
+# Start the application
+CMD ["yarn", "dev"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,18 +12,26 @@ services:
         exec redis-server --requirepass ${REDIS_PASSWORD}
     volumes: 
       - ${DOCKER_REDIS_VOLUME}/:/data:rw
-    ports: 
-      - ${REDIS_PORT}:6379
+      # if that does not work use
+      # ./data:/data:rw
+
 
   reminder-bot:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      args: 
+    # optionally pre-build the image
+    # image: reminder-bot:2024.02.19
+    environment:
         - REDIS_PORT=${REDIS_PORT}
         - REDIS_HOST=${REDIS_HOST}
         - REDIS_PASSWORD=${REDIS_PASSWORD}
+    # optionally: mount the zuliprc file. First create a volume "reminder-bot_data" and store the file there (or use ./path/to/file)
+    # volumes: 
+    #  - /var/lib/docker/volumes/reminder-bot_data/_data/zuliprc:/app/zuliprc:ro
+    build:
+      context: .
+      dockerfile: Dockerfile
     container_name: reminder-bot
     restart: unless-stopped
     depends_on: 
       - redis-db
+volumes:
+  data:

--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
   "license": "MIT",
   "devDependencies": {
     "@types/node": "^14.6.0",
-    "chrono-node": "^2.3.0",
     "nodemon": "^2.0",
     "ts-node": "^10",
     "typescript": "^4.2"
   },
   "dependencies": {
+    "chrono-node": "^2.3.0",
     "handy-redis": "^2.2.1",
     "redis": "^3.1.2",
     "timezone-support": "^2.0.2",


### PR DESCRIPTION
- use alpine to -60% image size
- make entrypoint.sh obsolete / optional
- full configuration with environment vars / no build-time configuration needed anymore
- added zuliprc file for bot mounting into docker-compose.yml